### PR TITLE
fix: remove incorrect requirement of bitcoind 'peers.listen' config

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,9 @@
 id: fulcrum
 title: 'Fulcrum'
-version: 2.1.0
-release-notes: |
-  Updated to Fulcrum v2.1.0 [Release notes](https://github.com/cculianu/Fulcrum/releases/tag/v2.1.0)
+version: 2.1.0.1
+release-notes: |  
+  * Updated to Fulcrum v2.1.0 [Release notes](https://github.com/cculianu/Fulcrum/releases/tag/v2.1.0)
+  * Fix incorrect config requirement for bitcoind.
 license: MIT
 wrapper-repo: 'https://github.com/linkinparkrulz/fulcrum-startos'
 upstream-repo: 'https://github.com/cculianu/Fulcrum'

--- a/scripts/procedures/dependencies.ts
+++ b/scripts/procedures/dependencies.ts
@@ -12,9 +12,6 @@ const matchBitcoindConfig = shape({
     enable: boolean,
   }),
   advanced: shape({
-    peers: shape({
-      listen: boolean,
-    }),
     pruning: shape({
       mode: string,
     }),
@@ -38,23 +35,6 @@ const bitcoindChecks: Array<Check> = [
         return
       }
       config.rpc.enable = true
-    },
-  },
-  {
-    currentError(config) {
-      if (!matchBitcoindConfig.test(config)) {
-        return 'Config is not the correct shape'
-      }
-      if (!config.advanced.peers.listen) {
-        return 'Must have peer interface enabled'
-      }
-      return
-    },
-    fix(config) {
-      if (!matchBitcoindConfig.test(config)) {
-        return
-      }
-      config.advanced.peers.listen = true
     },
   },
   {

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,4 @@
 import { compat, types as T } from "../deps.ts";
 
 export const migration: T.ExpectedExports.migration = compat.migrations
-    .fromMapping({}, "2.1.0" );
+    .fromMapping({}, "2.1.0.1" );


### PR DESCRIPTION
Fulcrum doesn't need this, might be a left-over from another service.